### PR TITLE
fix: use `reset` on ctx when clear

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -262,18 +262,18 @@ export class LetItGo {
   clear(): void {
     this.letItStop();
 
+    this.#number = 0;
     this.#snowflakes = [];
+
     if (this.#resizeObserver) {
       this.#resizeObserver.disconnect();
       this.#resizeObserver = null;
     }
 
+    this.#ctx.reset();
     if (this.canvas.parentNode) {
       this.root.removeChild(this.canvas);
     }
-
-    this.#ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.#number = 0;
   }
 }
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -12,6 +12,7 @@ const mockCanvasContext = {
   fill: vi.fn(),
   save: vi.fn(),
   restore: vi.fn(),
+  reset: vi.fn(),
   closePath: vi.fn(),
   globalAlpha: 1,
   fillStyle: '#000',


### PR DESCRIPTION
A simpler way, but note that browser support may be limited: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/reset